### PR TITLE
Rewrite integration test to work with new prompt history system

### DIFF
--- a/helix-term/tests/test/prompt.rs
+++ b/helix-term/tests/test/prompt.rs
@@ -4,7 +4,7 @@ use super::*;
 async fn test_history_completion() -> anyhow::Result<()> {
     test_key_sequence(
         &mut AppBuilder::new().build()?,
-        Some(":asdf<ret>:theme d<C-n><tab>"),
+        Some(":testingtheme dark<ret>:theme d<C-n><tab>"),
         Some(&|app| {
             assert!(!app.editor.is_err());
         }),


### PR DESCRIPTION
C-n would previously always take you back to the last entry; test data changed so it will still do this because it matches the currently entered prompt.